### PR TITLE
Allowing programmatic use of savePC

### DIFF
--- a/modules/shared/lib/save.js
+++ b/modules/shared/lib/save.js
@@ -47,7 +47,7 @@ if (NODE) {
  * @param {string} sPCJSFile
  * @return {boolean} true if successful, false if error
  */
-function savePC(idMachine, sPCJSFile)
+function savePC(idMachine, sPCJSFile, callback)
 {
     var cmp = /** @type {Computer} */ (Component.getComponentByType("Computer", idMachine));
     var dbg = /** @type {Debugger} */ (Component.getComponentByType("Debugger", idMachine));
@@ -61,6 +61,7 @@ function savePC(idMachine, sPCJSFile)
                 sPCJSFile = "/versions/pcjs/" + (XMLVERSION || APPVERSION) + "/pc" + (dbg? "-dbg" : "") + ".js";
             }
         }
+        if (callback && callback({ state: sState, parms: sParms })) return true;
         web.getResource(sPCJSFile, null, true, function(sURL, sResponse, nErrorCode) {
             downloadCSS(sURL, sResponse, nErrorCode, [idMachine, str.getBaseName(sPCJSFile, true), sParms, sState]);
         });


### PR DESCRIPTION
As per #20 **Expose API for taking/loading snapshots of VM** it would be great to be able to save machine state programmatically, to upload/manipulate the state.

This PR introduces an optional callback argument, that savePC invokes when the state is saved. If the callback returns true/truthy, the standard concatenation/download phase is omitted.
