### PR TITLE
Allow resources to be satisfied asynchronously

### DIFF
--- a/modules/shared/lib/weblib.js
+++ b/modules/shared/lib/weblib.js
@@ -197,6 +197,12 @@ web.getResource = function(sURL, dataPost, fAsync, done)
         if (done) done(sURL, sResource, nErrorCode);
         return [sResource, nErrorCode];
     }
+    else if (fAsync && typeof resources == 'function') {
+        resources(sURL, function(sResource, nErrorCode) {
+            if (done) done(sURL, sResource, nErrorCode);
+        });
+        return;
+    }
 
     if (DEBUG) {
         /*


### PR DESCRIPTION
As per #19 **Allow hosting web page to handle requests, instead of going XHR** already implemented with `resources` global variable, this extends the overriding ability with asynchronous fetch.

If `resources` is a function, it is invoked with `sURL` and a callback expecting result and error code.
