### PR TITLE
Allow building without global gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "tests"
   },
   "scripts": {
+    "build": "gulp",
     "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This allows building `pcjs` without global `gulp-cli` --- making it way easier to tinker on any random machine (or temporary VM etc.)

You would just `git clone`, `npm install` and finally `npm run build`.

```
pcjs $ npm run build

> pcjs@1.66.0 build /Users/***/pcjs-du/pcjs
> gulp

[17:15:38] Using gulpfile ~/pcjs-du/pcjs/gulpfile.js
[17:15:38] Starting 'default'...
[17:15:38] Starting 'concat/c1p'...
[17:15:38] Starting 'concat/leds'...
[17:15:38] Starting 'concat/pc8080'...
[17:15:38] Starting 'concat/pcx86'...

. . .

[17:15:38] Finished 'pcjs-disks' after 2.96 ms
[17:15:38] Finished 'private-disks' after 1.85 ms
[17:15:38] Starting 'disks'...
[17:15:38] Finished 'disks' after 2.19 μs

pcjs $ 
```

